### PR TITLE
Now sending port in client_id if needed.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,7 +10,13 @@ define( 'PMPROUP_AUTH', 'https://locksmith.unlock-protocol.com/api/oauth' );
  * @return string The domain name is used as the client_id for Unlock Protocol.
  */
 function pmproup_get_client_id() {
-	return wp_parse_url( home_url(), PHP_URL_HOST );
+	$parsed_url =  wp_parse_url( home_url() );
+	if ( ! empty( $parsed_url['host'] ) && ! empty( $parsed_url['port'] ) ) {
+		return $parsed_url['host'] . ':' . $parsed_url['port'];
+	} elseif( ! empty( $parsed_url['host'] ) ) {
+		return $parsed_url['host'];
+	}
+	return '';
 }
 
 


### PR DESCRIPTION
Fixes issue where sites run on a specific localhost port would not be able to interact with Unlock Protocol.