### PR TITLE
Setting default lock option to  false

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -308,7 +308,6 @@ function pmproup_has_membership_level( $has_level, $user_id, $levels ) {
 	$wallet = pmproup_try_to_get_wallet( $user_id );
 
 	// If no wallet is found, let's leave it to PMPro to handle.
-	var_dump( $level_lock_options );
 	if ( empty( $level_lock_options ) || empty( $wallet ) ) { /// Improve this check here.
 		return $has_level;
 	}


### PR DESCRIPTION
Fixes the following warnings:

Warning: Trying to access array offset on value of type bool in /Users/dparker1005/Local Sites/generaltesting/app/public/wp-content/plugins/pmpro-unlock/includes/functions.php on line 316

Warning: Trying to access array offset on value of type bool in /Users/dparker1005/Local Sites/generaltesting/app/public/wp-content/plugins/pmpro-unlock/includes/functions.php on line 345
