### PR TITLE
Now tracking membership levels purchased with NFT

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -14,7 +14,10 @@ function pmproup_add_wallet_to_checkout() {
     if ( is_wp_error( $wallet ) || ! $wallet ) {
         echo pmproup_connect_wallet_button();
     } else {
-        $level_lock_options = get_option( 'pmproup_' . $level_id, true );
+        $level_lock_options = get_option( 'pmproup_' . $level_id );
+        if ( empty( $level_lock_options ) ) {
+            return;
+        }
 
         // Let's check the validate lock status.
         $check_lock = pmproup_has_lock_access( $level_lock_options['network_rpc'], $level_lock_options['lock_address'], $wallet );
@@ -63,17 +66,34 @@ function pmproup_checkout_level( $checkout_level ) {
     }
        
     // Let's see if they have access to the lock now.
-    $check_lock = pmproup_has_lock_access( $level_lock_options['network_rpc'], $level_lock_options['lock_address'], $wallet );
 
-    if ( $check_lock ) {
-        $checkout_level->initial_payment = '0';
-        $checkout_level->billing_amount = '0';
-        $checkout_level->cycle_number = '0';
-        $checkout_level->cycle_period = '';
-        $checkout_level->billing_limit = '0';
-        $checkout_level->trial_amount = '0';
-        $checkout_level->trial_limit = '0';
+    if ( ! pmproup_has_lock_access( $level_lock_options['network_rpc'], $level_lock_options['lock_address'], $wallet ) ) {
+        return $checkout_level;
     }
+
+    // Make sure this NFT is not already used.
+    // TODO: Get an actual unique ID for the NFT to save and uncomment.
+    /*
+    $unique_lock_id = '1';
+    $query_args = array(
+        'meta_key' => 'pmproup_claimed_nft_' . $level_id,
+        'meta_value' => $unique_lock_id,
+    );
+    $query = new WP_User_Query( $query_args );
+    if ( $query->get_total() > 0 ) {
+        // NFT is already used.
+        return $checkout_level;
+    }
+    */
+
+    // User has access to the lock, let's set the price to 0.
+    $checkout_level->initial_payment = '0';
+    $checkout_level->billing_amount = '0';
+    $checkout_level->cycle_number = '0';
+    $checkout_level->cycle_period = '';
+    $checkout_level->billing_limit = '0';
+    $checkout_level->trial_amount = '0';
+    $checkout_level->trial_limit = '0';
 
     return $checkout_level;
 
@@ -114,3 +134,51 @@ function pmproup_registration_checks( $continue ) {
     return $continue;
 }
 add_filter( 'pmpro_registration_checks', 'pmproup_registration_checks' );
+
+/**
+ * After checkout, if an NFT was used, save the NFT ID to the user's metadata.
+ *
+ * @param int         $user_id The user ID.
+ * @param MemberOrder $morder The order object.
+ */
+function pmproup_after_checkout( $user_id, $morder ) {
+    // Get the level that was purchased.
+    $level_id = $morder->membership_id;
+
+    // Get the level's NFT settings.
+    $level_lock_options = get_option( 'pmproup_' . $level_id, true );
+
+    // If the level doesn't have any NFT settings, bail.
+    if ( empty( $level_lock_options ) || ! is_array( $level_lock_options ) || empty( $level_lock_options['network_rpc'] ) || empty( $level_lock_options['lock_address'] ) ) {
+        return;
+    }
+
+    // Get the user's wallet.
+    $wallet = pmproup_try_to_get_wallet();
+
+    // If user doesn't have a wallet, bail.
+    if ( is_wp_error( $wallet ) || ! $wallet ) {
+        return;
+    }
+
+    // Check if the user has access to the lock for this level.
+    if ( pmproup_has_lock_access( $level_lock_options['network_rpc'], $level_lock_options['lock_address'], $wallet ) ) {
+        // Save the ID for the NFT used to unlock this level in user meta.
+        // TODO: Get an actual unique ID for the NFT to save.
+        $unique_lock_id = '1';
+        update_user_meta( $user_id, 'pmproup_claimed_nft_' . $level_id, $unique_lock_id );
+    }
+}
+
+/**
+ * After a membership level is cancelled, remove the NFT ID from the user's meta.
+ *
+ * @param int $level_id The level ID.
+ * @param int $user_id The user ID.
+ * @param int $cancel_level_id The level ID that was cancelled.
+ */
+function pmproup_after_cancel_membership_level( $level_id, $user_id, $cancel_level_id ) {
+    // Remove the NFT ID from the user's meta.
+    delete_user_meta( $user_id, 'pmproup_claimed_nft_' . $cancel_level_id );
+}
+add_action( 'pmpro_after_change_membership_level', 'pmproup_after_cancel_membership_level', 10, 3 );


### PR DESCRIPTION
I couldn't figure out how to trade an NFT away so I couldn't test this code.

The idea here is to track membership levels that were purchased via NFT with a membership level. We can then use that information when we are determining access so that we know when we need to check if a user still has a NFT.

Also fixes some other various PHP warnings.