### PR TITLE
Caching NFT validity to improve performance.

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -129,6 +129,8 @@ function pmproup_registration_checks( $continue ) {
     
     if ( ! $continue ) {
         pmpro_setMessage( 'You need an NFT to claim this membership', 'pmpro_error' ); // Change this.
+    } else {
+        pmproup_clear_transients( $level_lock_options['lock_address'], $wallet );
     }
 
     return $continue;
@@ -167,6 +169,8 @@ function pmproup_after_checkout( $user_id, $morder ) {
         // TODO: Get an actual unique ID for the NFT to save.
         $unique_lock_id = '1';
         update_user_meta( $user_id, 'pmproup_claimed_nft_' . $level_id, $unique_lock_id );
+
+        pmproup_clear_transients( $level_lock_options['lock_address'], $wallet );
     }
 }
 


### PR DESCRIPTION
* General Improvements and caching data on a per lock/wallet basis, this caches data every two hours but should be enough. We can cache it shorter if needed. Improves page load times.
* Adjusted to use sanitize_url for the network URL.
* Adjusted conditionals in the pmproup_should_have_access function to try and improve performance.
* Added logic to clear transients when checking out, when we check for NFT access.