### PR TITLE
If editing user, show wallet for that user

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -12,7 +12,7 @@
 function pmproup_profile_connect_wallet( $user ) {
 
     // Let's try to check and save it on page load.
-    $wallet_address = pmproup_check_save_wallet();
+    $wallet_address = empty( $user->ID ) ? pmproup_check_save_wallet() : pmproup_check_save_wallet( $user->ID );
 
     if ( empty( $wallet_address ) || is_wp_error( $wallet_address ) ) {
         pmproup_connect_wallet_button(); //Show the button, let's try to save it.


### PR DESCRIPTION
Looking at the existing code, there is currently not a user being passed to `pmproup_check_save_wallet()`. This means that the code would run for the current logged in user. If we are editing a user, then this is not what we want.