### PR TITLE
Add member edit panel

### DIFF
--- a/classes/pmproup-class-member-edit-panel.php
+++ b/classes/pmproup-class-member-edit-panel.php
@@ -1,0 +1,26 @@
+<?php
+
+class PMProup_Member_Edit_Panel extends PMPro_Member_Edit_Panel {
+	/**
+	 * Set up the panel.
+	 */
+	public function __construct() {
+		$this->slug        = 'pmproup';
+		$this->title       = __( 'Unlock Protocol Integration', 'pmpro-unlock' );
+        $this->submit_text = __( 'Save', 'pmpro-unlock' );
+	}
+
+	/**
+	 * Display the panel contents.
+	 */
+	protected function display_panel_contents() {
+		pmproup_profile_connect_wallet( self::get_user() );
+	}
+
+    /**
+     * Remove the wallet address if the remove option is selected.
+     */
+    public function save() {
+        pmproup_profile_remove_wallet();
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -177,7 +177,19 @@ function pmproup_connect_wallet_button( $state = null ) {
 	global $pmpro_pages;
 	
 	if ( is_admin() ) {
-		$redirect_uri = admin_url( basename( $_SERVER['REQUEST_URI'] ) );
+		if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-member' ) {
+			// We are on the Member Edit page. We need to pass the panel slug to save properly.
+			$redirect_uri = add_query_arg(
+				array(
+					'page'                    => 'pmpro-member',
+					'user_id'                 => empty( $_REQUEST['user_id'] ) ? '' : intval( $_REQUEST['user_id'] ),
+					'pmpro_member_edit_panel' => 'pmproup',
+				),
+				admin_url( 'admin.php' )
+			);
+		} else {
+			$redirect_uri = admin_url( basename( $_SERVER['REQUEST_URI'] ) );
+		}
 	} elseif( is_page( $pmpro_pages['checkout'] ) ) {
 		if ( isset( $_REQUEST['level'] ) ) {
 			$redirect_uri = add_query_arg( 'level', intval( $_REQUEST['level'] ), get_permalink( $pmpro_pages['checkout'] ) );

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -39,7 +39,6 @@ function pmproup_profile_connect_wallet( $user ) {
     }
 }
 add_action( 'pmpro_show_user_profile', 'pmproup_profile_connect_wallet', 10, 1 );
-add_action( 'pmpro_after_membership_level_profile_fields', 'pmproup_profile_connect_wallet', 10, 1 );
 
 /**
  * Delete wallet address if remove option is selected.
@@ -58,3 +57,42 @@ function pmproup_profile_remove_wallet() {
 
 }
 add_action( 'profile_update', 'pmproup_profile_remove_wallet' );
+
+/**
+ * Add a panel to the Edit Member dashboard page.
+ *
+ * @since TBD
+ *
+ * @param array $panels Array of panels.
+ * @return array
+ */
+function pmproup_pmpro_member_edit_panels( $panels ) {
+	// If the class doesn't exist and the abstract class does, require the class.
+	if ( ! class_exists( 'PMProup_Member_Edit_Panel' ) && class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+		require_once( PMPROUP_DIR . '/classes/pmproup-class-member-edit-panel.php' );
+	}
+
+	// If the class exists, add a panel.
+	if ( class_exists( 'PMProup_Member_Edit_Panel' ) ) {
+		$panels[] = new PMProup_Member_Edit_Panel();
+	}
+
+	return $panels;
+}
+
+/**
+ * Hook the correct function for admins editing a member's profile.
+ *
+ * @since TBD
+ */
+function pmproup_hook_edit_member_profile() {
+	// If the `pmpro_member_edit_get_panels()` function exists, add a panel.
+	// Otherwise, use the legacy hook.
+	if ( function_exists( 'pmpro_member_edit_get_panels' ) ) {
+		add_filter( 'pmpro_member_edit_panels', 'pmproup_pmpro_member_edit_panels' );
+	} else {
+		add_action( 'pmpro_after_membership_level_profile_fields', 'pmproup_profile_connect_wallet', 10, 1 );
+		add_action( 'profile_update', 'pmproup_profile_remove_wallet' );
+	}
+}
+add_action( 'admin_init', 'pmproup_hook_edit_member_profile', 0 );


### PR DESCRIPTION
Adds a panel to the Member Edit page for PMPro v3.0+.

Resolves #13 

This is necessary for the wallet to save correctly after being connected by an administrator. I have tested this code to ensure that the button shows correctly and generate the correct `$redirect_uri`, but do not have an environment currently set up to test the entire connection flow. This should be a quick test when reviewing/merging the PR.